### PR TITLE
Add Escript and Erlang Config filetypes

### DIFF
--- a/grammars/erlang-config.cson
+++ b/grammars/erlang-config.cson
@@ -1,0 +1,14 @@
+'fileTypes': [
+  'config',
+  'rel',
+  'script',
+  'app',
+  'app.src'
+]
+'name': 'Erlang Config File (Erlang Term File)'
+'patterns': [
+  {
+    'include': 'source.erlang'
+  }
+]
+'scopeName': 'source.erlang.config'

--- a/grammars/erlang.cson
+++ b/grammars/erlang.cson
@@ -2,6 +2,7 @@
 'fileTypes': [
   'erl'
   'hrl'
+  'escript'
 ]
 'name': 'Erlang'
 'patterns': [


### PR DESCRIPTION
Hello,

Added missing .escript (Erlang Scripts) file type along .erl and .hrl.
Added missing file type definitions which are widely used in Erlang/OTP projects with rebar.

Cheers.
