### PR TITLE
Add leex and yecc file type support

### DIFF
--- a/grammars/erlang.cson
+++ b/grammars/erlang.cson
@@ -2,6 +2,8 @@
 'fileTypes': [
   'erl'
   'hrl'
+  'xrl'
+  'yrl'
 ]
 'name': 'Erlang'
 'patterns': [


### PR DESCRIPTION
I've been working with `leex` and `yecc` and would love to have auto-syntax highlighting for my `.xrl` and `.yrl` files.
