### PR TITLE
Add syntax highlighting and recognition of shebang lines

### DIFF
--- a/grammars/erlang.cson
+++ b/grammars/erlang.cson
@@ -3,6 +3,7 @@
   'erl'
   'hrl'
 ]
+'firstLineMatch': '^#!.*\\b(escript)'
 'name': 'Erlang'
 'patterns': [
   {

--- a/grammars/erlang.cson
+++ b/grammars/erlang.cson
@@ -6,6 +6,9 @@
 'name': 'Erlang'
 'patterns': [
   {
+    'include': '#shebang'
+  }
+  {
     'include': '#module-directive'
   }
   {
@@ -1213,6 +1216,9 @@
         ]
       }
     ]
+  'shebang':
+    'match': '\\A#!.*$'
+    'name': 'comment.line.shebang.erlang'
   'string':
     'begin': '(")'
     'beginCaptures':


### PR DESCRIPTION
Currently, the grammar doesn't highlight shebangs, which're rendered like this:

<img src="https://cloud.githubusercontent.com/assets/2346707/14138268/1223cece-f6b8-11e5-9ac0-429624517e9d.png" alt="Figure 1" width="408" />

This PR fixes that:

<img src="https://cloud.githubusercontent.com/assets/2346707/14138311/5a6b03c8-f6b8-11e5-9ee3-e0386f53e0a2.png" alt="Figure 2" width="408" />

It also includes a `firstLineMatch` rule to enable the Erlang grammar for files without extensions - common among [Escripts](http://erlang.org/doc/man/escript.html).