### PR TITLE
add \x hex number notation for strings/atoms/chars

### DIFF
--- a/grammars/erlang.cson
+++ b/grammars/erlang.cson
@@ -57,7 +57,7 @@
                 'name': 'punctuation.definition.escape.erlang'
               '3':
                 'name': 'punctuation.definition.escape.erlang'
-            'match': '(\\\\)([bdefnrstv\\\\\'"]|(\\^)[@-_]|[0-7]{1,3})'
+            'match': '(\\\\)([bdefnrstv\\\\\'"]|(\\^)[@-_]|[0-7]{1,3}|x[0-9a-fA-F]{2})'
             'name': 'constant.other.symbol.escape.erlang'
           }
           {
@@ -125,7 +125,7 @@
             'name': 'punctuation.definition.escape.erlang'
           '5':
             'name': 'punctuation.definition.escape.erlang'
-        'match': '(\\$)((\\\\)([bdefnrstv\\\\\'"]|(\\^)[@-_]|[0-7]{1,3}))'
+        'match': '(\\$)((\\\\)([bdefnrstv\\\\\'"]|(\\^)[@-_]|[0-7]{1,3}|x[0-9a-fA-F]{2}))'
         'name': 'constant.character.erlang'
       }
       {
@@ -1237,7 +1237,7 @@
             'name': 'punctuation.definition.escape.erlang'
           '3':
             'name': 'punctuation.definition.escape.erlang'
-        'match': '(\\\\)([bdefnrstv\\\\\'"]|(\\^)[@-_]|[0-7]{1,3})'
+        'match': '(\\\\)([bdefnrstv\\\\\'"]|(\\^)[@-_]|[0-7]{1,3}|x[0-9a-fA-F]{2})'
         'name': 'constant.character.escape.erlang'
       }
       {


### PR DESCRIPTION
All those are valid in Erlang:

```
Erlang/OTP 18 [erts-7.3] [source] [64-bit] [smp:4:4] [async-threads:10] [kernel-poll:false]

Eshell V7.3  (abort with ^G)
1> '\x61'.
a
2> "\x61".
"a"
3> $\x61.
97
4>
```

solves #15 
