### PR TITLE
Add firstLineSupport for Emacs/Vim modelines

### DIFF
--- a/grammars/erlang.cson
+++ b/grammars/erlang.cson
@@ -3,7 +3,25 @@
   'erl'
   'hrl'
 ]
-'firstLineMatch': '^#!.*\\b(escript)'
+'firstLineMatch': '''(?x)
+  # Hashbang
+  ^\\#!.*(?:\\s|\\/)
+    escript
+  (?:$|\\s)
+  |
+  # Modeline
+  (?i:
+    # Emacs
+    -\\*-(?:\\s*(?=[^:;\\s]+\\s*-\\*-)|(?:.*?[;\\s]|(?<=-\\*-))mode\\s*:\\s*)
+      erlang
+    (?=[\\s;]|(?<![-*])-\\*-).*?-\\*-
+    |
+    # Vim
+    (?:(?:\\s|^)vi(?:m[<=>]?\\d+|m)?|\\sex)(?=:(?=\\s*set?\\s[^\\n:]+:)|:(?!\\s*set?\\s))(?:(?:\\s|\\s*:\\s*)\\w*(?:\\s*=(?:[^\\n\\\\\\s]|\\\\.)*)?)*[\\s:](?:filetype|ft|syntax)\\s*=
+      erlang
+    (?=\\s|:|$)
+  )
+'''
 'name': 'Erlang'
 'patterns': [
   {


### PR DESCRIPTION
This enables the grammar to activate for any file containing an Erlang modeline in the first line:

**Emacs:**

``` erlang
% -*- erlang -*-
```

**Vim:**

``` erlang
% vim: set filetype=erlang:
```

The practice is quite common with files using non Erlang-like extensions... have a [look for yourself](https://github.com/search?q=set+filetype%3Derlang&type=Code&utf8=%E2%9C%93).

BTW, these are the same modeline-matching patterns that've been added to Atom's core grammars, as well as [GitHub's program](https://github.com/github/linguist/blob/master/lib/linguist/strategy/modeline.rb) that performs language classification and recognition. =)
