### PR TITLE
Add function-punctuation to grammer to help with FiraCode font rendering

### DIFF
--- a/grammars/erlang.cson
+++ b/grammars/erlang.cson
@@ -300,6 +300,9 @@
         'include': '#function-call'
       }
       {
+        'include': '#function-punctuation'
+      }
+      {
         'include': '#tuple'
       }
       {
@@ -575,6 +578,11 @@
         ]
       }
     ]
+  'function-punctuation':
+    'captures':
+      '1':
+        'name': 'punctuation.separator.function-punctuation-head-body.erlang'
+    'match': '(->)'
   'import-export-directive':
     'patterns': [
       {


### PR DESCRIPTION
This fix lets arrows, `->` that are not considered `internal-expression-punctuation` render properly in [FiraCode](https://github.com/tonsky/FiraCode)

Example Before Fix:
<img width="594" alt="screen shot 2017-03-29 at 5 18 12 pm" src="https://cloud.githubusercontent.com/assets/578584/24479229/c4652f24-14a3-11e7-9c29-d398a352f9f4.png">

Example After Fix:
<img width="590" alt="screen shot 2017-03-29 at 5 19 03 pm" src="https://cloud.githubusercontent.com/assets/578584/24479241/d6f57dba-14a3-11e7-8e95-1d69e9093ef1.png">
