### PR TITLE
separate function arrow as symbolic operator

### DIFF
--- a/grammars/erlang.cson
+++ b/grammars/erlang.cson
@@ -1281,7 +1281,7 @@
       }
     ]
   'symbolic-operator':
-    'match': '\\+\\+|\\+|--|-|\\*|/=|/|=/=|=:=|==|=<|=|<-|<|>=|>|!|::'
+    'match': '\\+\\+|\\+|--|->|-|\\*|/=|/|=/=|=:=|==|=<|=|<-|<|>=|>|!|::'
     'name': 'keyword.operator.symbolic.erlang'
   'textual-operator':
     'match': '\\b(andalso|band|and|bxor|xor|bor|orelse|or|bnot|not|bsl|bsr|div|rem)\\b'


### PR DESCRIPTION
Separate the function arrow as a symbolic operator so that it can be used by programming ligatures such as https://github.com/tonsky/FiraCode