### PR TITLE
reorder list comp separator definition

### DIFF
--- a/grammars/erlang.cson
+++ b/grammars/erlang.cson
@@ -788,7 +788,7 @@
     'name': 'meta.structure.list.erlang'
     'patterns': [
       {
-        'match': '\\||\\|\\||,'
+        'match': '\\|\\||\\||,'
         'name': 'punctuation.separator.list.erlang'
       }
       {


### PR DESCRIPTION
This is a request very similar to
- https://github.com/jonathanmarvens/atom-language-erlang/pull/24
- https://github.com/jonathanmarvens/atom-language-erlang/pull/23

Programming ligatures aren't picking up the `||` list comprehension separator due to the order of it's RegExp.